### PR TITLE
Add flight parameters guide

### DIFF
--- a/docs/flight-parameters.md
+++ b/docs/flight-parameters.md
@@ -1,0 +1,52 @@
+# ✈️ Flight Parameters
+
+Understanding each setting helps you produce better imagery. OpenFlightPlan pulls defaults from `drone_specs.py` when you choose your drone model.
+
+---
+
+## Altitude
+
+- Determines ground resolution and coverage area.
+- Stay within your drone's limits (max 120 m for DJI models).
+- Higher altitude = fewer images but lower detail.
+
+## Speed
+
+- How fast the drone travels along the path.
+- Constrained by your drone's capability (up to 21 m/s for a Mavic 3 Pro).
+- Slower speeds allow longer exposure times and better overlap.
+
+## Front Overlap
+
+- Percentage each image overlaps the previous one along the flight direction.
+- Typical orthomosaics use **70%+**.
+
+## Sidelap
+
+- Overlap between adjacent flight lines.
+- Aim for **60–70%** for mapping to avoid gaps.
+
+## Interval
+
+- Time between photo triggers.
+- Minimum of **0.5 s** based on DJI specs.
+
+## FOV
+
+- Camera field of view in degrees (about **82°** on most DJI models).
+- A wider FOV covers more ground but increases distortion near edges.
+
+---
+
+## Orthomosaic Tips
+
+- Fly **nadir** (camera pointing straight down).
+- Use higher overlap and sidelap for photogrammetry.
+- Moderate altitude (60–100 m) balances detail and coverage.
+
+## Oblique Mission Tips
+
+- Tilt the camera and fly concentric circles for 3D models.
+- Use several layers at different altitudes.
+- Reduce speed to maintain blur‑free images.
+

--- a/docs/using-the-app.md
+++ b/docs/using-the-app.md
@@ -23,6 +23,9 @@ Fine-tune your settings:
 | Interval | Camera trigger interval |
 | FOV | Field of view of camera |
 
+For a deeper explanation of these values and how they impact your mission, see
+[Flight Parameters](flight-parameters.md).
+
 ---
 
 ## 📥 Export Options

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,15 @@ site_name: OpenFlightPlan Docs
 site_url: https://docs.openflightplan.io
 repo_url: https://github.com/mostrager/mobile-flight-planner
 repo_name: GitHub
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Using the App: using-the-app.md
+  - Flight Parameters: flight-parameters.md
+  - Mobile Optimization: mobile.md
+  - Developer Guide: developer-guide.md
+  - Contributing: CONTRIBUTING.md
+  - License: license.md
 theme:
   name: material
   palette:


### PR DESCRIPTION
## Summary
- document common flight parameters and tips
- link to the guide from the Using the App page
- add the new guide to site navigation

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68899c1736088328b41b50cbbe87b186