### PR TITLE
Add README and remove MkDocs header links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# OpenFlightPlan
+
+OpenFlightPlan is a **mobile-first** mission planning tool for creating flight grids for orthomosaics and 3D modeling. The app runs in the browser using Streamlit so you can plan missions directly from your phone.
+
+## Features
+
+- Draw polygons or circles to define your mission area
+- Configure altitude, overlap, speed and other flight parameters
+- Export flight plans as CSV and KMZ files
+- No user accounts required
+- Completely open source
+
+## Local setup
+
+```bash
+git clone https://github.com/mostrager/mobile-flight-planner.git
+cd mobile-flight-planner
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+streamlit run app.py
+```
+
+For more details see the [documentation](https://docs.openflightplan.io/).
+
+Licensed under the MIT License.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,5 @@
 site_name: OpenFlightPlan Docs
 site_url: https://docs.openflightplan.io
-repo_url: https://github.com/mostrager/mobile-flight-planner
-repo_name: GitHub
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
@@ -17,9 +15,6 @@ theme:
     - scheme: default
       primary: indigo
       accent: light blue
-    - scheme: slate
-      primary: teal
-      accent: cyan
   font:
     text: "Open Sans"
     code: "Fira Code"


### PR DESCRIPTION
## Summary
- create README explaining project and usage
- remove repo URL and additional palette from MkDocs config so no GitHub link or theme toggle is shown

## Testing
- `python -m compileall -q app.py contact_section.py flight_calculator.py dji_export.py drone_specs.py map_utils.py utils.py pages/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6889be287cf483289cd85bcd66f36ffe